### PR TITLE
use mass assign to assign values

### DIFF
--- a/lib/pluck_all.rb
+++ b/lib/pluck_all.rb
@@ -72,9 +72,10 @@ private
       @pluck_all_cast_klass ||= klass
       @pluck_all_uploaders ||= @pluck_all_cast_klass.uploaders.select{|key, uploader| attributes.key?(key.to_s) }
       @pluck_all_uploaders.each do |key, uploader|
-        obj = @pluck_all_cast_klass.new
+        hash = {}
+        @pluck_all_cast_need_columns.each{|k| hash[k] = attributes[k] } if @pluck_all_cast_need_columns
+        obj = @pluck_all_cast_klass.new(hash)
         obj[key] = attributes[key_s = key.to_s]
-        @pluck_all_cast_need_columns.each{|s| obj[s] = attributes[s] } if @pluck_all_cast_need_columns
         attributes[key_s] = obj.send(:_mounter, key).uploader #uploaders.first
       end
     end


### PR DESCRIPTION
if you have callback to set default values
```rb
after_initialize :set_default_values
def set_default_values
  return unless new_record?
  self.code ||= self.class.generate_code
end
```
and pluck a carrierwave column
this line may cause a N+1 query problem https://github.com/khiav223577/pluck_all/compare/master...feature/use_rails_assign#diff-9a3602724c8d67fccc8a0c285be90091R77
