### PR TITLE
Restrict dependency to activerecord

### DIFF
--- a/pluck_all.gemspec
+++ b/pluck_all.gemspec
@@ -32,6 +32,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "sqlite3", "~> 1.3"
   spec.add_development_dependency "minitest", "~> 5.0"
 
-  spec.add_dependency "rails", ">= 3"
+  spec.add_dependency "activerecord", ">= 3"
 
 end


### PR DESCRIPTION
The gem doesn't need the whole rails stack to work.