### PR TITLE
Fix test cases and the result format may be wrong when plucking multiple columns with nil value may

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ before_install:
   - chmod +x ./cc-test-reporter
   - ./cc-test-reporter before-build
 script:
-  - if [ "$ORM_TYPE" = "ACTIVE_RECORD" ]; then bundle exec rake test/active_record; fi
-  - if [ "$ORM_TYPE" = "MONGOID" ]; then bundle exec rake test/mongoid; fi
+  - if [ "$ORM_TYPE" = "ACTIVE_RECORD" ]; then bundle exec rake test_active_record; fi
+  - if [ "$ORM_TYPE" = "MONGOID" ]; then bundle exec rake test_mongoid; fi
 after_script:
   - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT

--- a/Rakefile
+++ b/Rakefile
@@ -7,4 +7,16 @@ Rake::TestTask.new(:test) do |t|
   t.test_files = FileList['test/**/*_test.rb']
 end
 
+Rake::TestTask.new(:test_active_record) do |t|
+  t.libs << "test"
+  t.libs << "lib"
+  t.test_files = FileList['test/active_record/**/*_test.rb']
+end
+
+Rake::TestTask.new(:test_mongoid) do |t|
+  t.libs << "test"
+  t.libs << "lib"
+  t.test_files = FileList['test/mongoid/**/*_test.rb']
+end
+
 task :default => :test

--- a/lib/pluck_all/models/active_record_extension.rb
+++ b/lib/pluck_all/models/active_record_extension.rb
@@ -74,21 +74,17 @@ class ActiveRecord::Relation
     if defined?(CarrierWave) && klass.respond_to?(:uploaders)
       @pluck_all_cast_klass ||= klass
       @pluck_all_uploaders ||= @pluck_all_cast_klass.uploaders.select{|key, uploader| attributes.key?(key.to_s) }
-      @pluck_all_uploaders.each(&pluck_all_uploaders_key_mapper)
-    end
-    return attributes
-  end
-
-  def pluck_all_uploaders_key_mapper
-    Proc.new do |key, uploader|
-      {}.tap do |hash|
-        @pluck_all_cast_need_columns.each{|k| hash[k] = attributes[k] } if @pluck_all_cast_need_columns
-        obj = @pluck_all_cast_klass.new(hash)
-        obj[key] = attributes[key_s = key.to_s]
-        #https://github.com/carrierwaveuploader/carrierwave/blob/87c37b706c560de6d01816f9ebaa15ce1c51ed58/lib/carrierwave/mount.rb#L142
-        attributes[key_s] = obj.send(key)
+      @pluck_all_uploaders.each do |key, uploader|
+        {}.tap do |hash|
+          @pluck_all_cast_need_columns.each{|k| hash[k] = attributes[k] } if @pluck_all_cast_need_columns
+          obj = @pluck_all_cast_klass.new(hash)
+          obj[key] = attributes[key_s = key.to_s]
+          #https://github.com/carrierwaveuploader/carrierwave/blob/87c37b706c560de6d01816f9ebaa15ce1c51ed58/lib/carrierwave/mount.rb#L142
+          attributes[key_s] = obj.send(key)
+        end
       end
     end
+    return attributes
   end
 end
 

--- a/lib/pluck_all/models/mongoid_extension.rb
+++ b/lib/pluck_all/models/mongoid_extension.rb
@@ -21,7 +21,7 @@ module Mongoid
       def pluck_array(*fields)
         normalized_select = get_normalized_select(fields)
         get_query_data(normalized_select).reduce([]) do |plucked, doc|
-          values = normalized_select.keys.map(&plucked_value_mapper(:array))
+          values = normalized_select.keys.map(&plucked_value_mapper(:array, doc))
           plucked << (values.size == 1 ? values.first : values)
         end
       end
@@ -29,14 +29,14 @@ module Mongoid
       def pluck_all(*fields)
         normalized_select = get_normalized_select(fields)
         get_query_data(normalized_select).reduce([]) do |plucked, doc|
-          values = normalized_select.keys.map(&plucked_value_mapper(:all))
+          values = normalized_select.keys.map(&plucked_value_mapper(:all, doc))
           plucked << values.to_h
         end
       end
 
       private
 
-      def plucked_value_mapper(type)
+      def plucked_value_mapper(type, doc)
         Proc.new do |n|
           values = [n, n =~ /\./ ? doc[n.partition('.')[0]] : doc[n]]
           case type

--- a/lib/pluck_all/models/mongoid_extension.rb
+++ b/lib/pluck_all/models/mongoid_extension.rb
@@ -1,5 +1,15 @@
 # frozen_string_literal: true
 module Mongoid
+  module Document::ClassMethods
+    def pluck_array(*fields)
+      where(nil).pluck_array(*fields)
+    end
+
+    def pluck_all(*fields)
+      where(nil).pluck_all(*fields)
+    end
+  end
+
   module Findable
     delegate :pluck_all, :pluck_array, to: :with_default_scope
   end

--- a/test/active_record/pluck_array_test.rb
+++ b/test/active_record/pluck_array_test.rb
@@ -18,6 +18,14 @@ class ActiveRecordPluckArrayTest < Minitest::Test
     ], User.pluck_array(:name, :email))
   end
 
+  def test_pluck_multiple_columns_with_nil_value
+    assert_equal([
+      ["John", nil],
+      ["Pearl", nil],
+      ["Kathenrie", 'Pet.png'],
+    ], User.pluck_array(:name, :pet_pic))
+  end
+
   def test_pluck_serialized_attribute
     assert_equal([
       {},


### PR DESCRIPTION
Only occurs In Rails 3.2
```rb
# wrong
User.pluck_array(:id, :other_column)
# => [1, 2, [3, xxx]]

# correct
User.pluck_array(:id, :other_column)
# => [[1, nil], [2, nil], [3, xxx]]
```