### PR TITLE
Use instantiate method to initialize model without calling callbacks

### DIFF
--- a/lib/pluck_all/models/active_record_extension.rb
+++ b/lib/pluck_all/models/active_record_extension.rb
@@ -85,7 +85,7 @@ class ActiveRecord::Relation
       @pluck_all_uploaders.each do |key, _uploader|
         {}.tap do |hash|
           @pluck_all_cast_need_columns.each{|k| hash[k] = attributes[k] } if @pluck_all_cast_need_columns
-          obj = @pluck_all_cast_klass.new(hash)
+          obj = @pluck_all_cast_klass.instantiate(hash)
           obj[key] = attributes[key_s = key.to_s]
           # https://github.com/carrierwaveuploader/carrierwave/blob/87c37b706c560de6d01816f9ebaa15ce1c51ed58/lib/carrierwave/mount.rb#L142
           attributes[key_s] = obj.send(key)

--- a/test/active_record/carrierwave_test.rb
+++ b/test/active_record/carrierwave_test.rb
@@ -2,17 +2,21 @@
 require_relative 'active_record_test_helper'
 
 class ActiveRecordPluckAllTest < Minitest::Test
+  def setup
+    @users = User.where(name: %w[Pearl Doggy])
+  end
+
   def test_pluck_with_carrierwave
     assert_equal([
       { 'name' => 'Pearl', 'profile_pic' => nil },
       { 'name' => 'Doggy', 'profile_pic' => '/uploads/user/profile_pic/Doggy/Profile.jpg' },
-    ], User.where(name: %w[Pearl Doggy]).cast_need_columns(%i[name]).pluck_all(:name, :profile_pic).each do |s|
+    ], @users.cast_need_columns(%i[name]).pluck_all(:name, :profile_pic).each do |s|
       s['profile_pic'] = s['profile_pic'].url
     end)
     assert_equal([
       { 'name' => 'Pearl', 'profile_pic' => nil },
       { 'name' => 'Doggy', 'profile_pic' => '/uploads/user/profile_pic/Doggy/tiny_Profile.jpg' },
-    ], User.where(name: %w[Pearl Doggy]).cast_need_columns(%i[name]).pluck_all(:name, :profile_pic).each do |s|
+    ], @users.cast_need_columns(%i[name]).pluck_all(:name, :profile_pic).each do |s|
       s['profile_pic'] = s['profile_pic'].tiny.url
     end)
   end
@@ -33,17 +37,13 @@ class ActiveRecordPluckAllTest < Minitest::Test
     assert_equal([
       { 'name' => 'Pearl', 'profile_pic' => nil },
       { 'name' => 'Doggy', 'profile_pic' => 'Profile.jpg' },
-    ], User.where(name: %w[Pearl Doggy]).cast_need_columns(%i[name]).pluck_all(:name, :profile_pic))
+    ], @users.cast_need_columns(%i[name]).pluck_all(:name, :profile_pic))
     Object.const_set(:CarrierWave, const)
   end
 
   def test_pluck_without_cast_need_columns
-    assert_equal([
-      { 'name' => 'Pearl', 'pet_pic' => nil },
-      { 'name' => 'Doggy', 'pet_pic' => '/uploads/user/pet_pic/Pet.png' },
-    ], User.where(name: %w[Pearl Doggy]).pluck_all(:name, :pet_pic).each do |s|
-      s['pet_pic'] = s['pet_pic'].url
-    end)
+    error = assert_raises(ActiveModel::MissingAttributeError){ @users.pluck_all(:name, :pet_pic) }
+    assert_equal 'missing attribute: name', error.message
   end
 
   def test_pluck_with_carrierwave_and_join


### PR DESCRIPTION
It changes original behavior, but it make sense to me.

### Original behavior

The url of `pet_pic` is not correct in the second example since it doesn't call `cast_need_columns` before calling `pluck_all`.
But there is no warning or exception raised.

```rb
@users.cast_need_columns(%i[name]).pluck_all(:name, :pet_pic)
# => ['name' => 'Doggy', 'pet_pic' => '/uploads/user/pet_pic/Doggy/Pet.png']

@users.pluck_all(:name, :pet_pic)
# => ['name' => 'Doggy', 'pet_pic' => '/uploads/user/pet_pic/Pet.png']
```

### New behavior

```rb
@users.cast_need_columns(%i[name]).pluck_all(:name, :pet_pic)
# => ['name' => 'Doggy', 'pet_pic' => '/uploads/user/pet_pic/Doggy/Pet.png']

@users.pluck_all(:name, :pet_pic)
# ActiveModel::MissingAttributeError: missing attribute: name
```

