### PR TITLE
fix Rails 6.1 `map!` deprecation warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ gemfile:
   - gemfiles/active_record_51.gemfile
   - gemfiles/active_record_52.gemfile
   - gemfiles/active_record_60.gemfile
+  - gemfiles/active_record_61.gemfile
   - gemfiles/mongoid_54.gemfile
   - gemfiles/mongoid_64.gemfile
   - gemfiles/mongoid_70.gemfile
@@ -43,6 +44,10 @@ matrix:
     - gemfile: gemfiles/active_record_60.gemfile
       rvm: 2.2
     - gemfile: gemfiles/active_record_60.gemfile
+      env: ORM_TYPE=MONGOID
+    - gemfile: gemfiles/active_record_61.gemfile
+      rvm: 2.2
+    - gemfile: gemfiles/active_record_61.gemfile
       env: ORM_TYPE=MONGOID
     - gemfile: gemfiles/mongoid_54.gemfile
       rvm: 2.7

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ feel free to use this gem and no need to worry about upgrading to Rails 4, 5, 6 
 
 ## Supports
 - Ruby 2.2 ~ 2.7
-- Rails 3.2, 4.2, 5.0, 5.1, 5.2, 6.0
+- Rails 3.2, 4.2, 5.0, 5.1, 5.2, 6.0, 6.1
 
 ## Installation
 

--- a/gemfiles/active_record_61.gemfile
+++ b/gemfiles/active_record_61.gemfile
@@ -1,0 +1,13 @@
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in pluck_all.gemspec
+
+gem 'sqlite3',      '~> 1.4.1'
+gem 'activerecord', '~> 6.1.0'
+gem 'carrierwave',  '~> 0.11.0'
+
+group :test do
+  gem 'simplecov'
+end
+
+gemspec path: '../'

--- a/lib/pluck_all/models/active_record_extension.rb
+++ b/lib/pluck_all/models/active_record_extension.rb
@@ -51,7 +51,7 @@ class ActiveRecord::Relation
       end
       result = select_all(*column_names)
       attribute_types = RailsCompatibility.attribute_types(klass)
-      result.map! do |attributes| # This map! behaves different to array#map!
+      result.map do |attributes| # This map behaves different to array#map
         attributes.each do |key, attribute|
           attributes[key] = result.send(:column_type, key, attribute_types).deserialize(attribute) # TODO: 現在AS過後的type cast會有一點問題，但似乎原生的pluck也有此問題
         end
@@ -80,6 +80,7 @@ class ActiveRecord::Relation
   # ----------------------------------------------------------------
   def cast_carrier_wave_uploader_url(attributes)
     if defined?(CarrierWave) && klass.respond_to?(:uploaders)
+      @pluck_all_cast_need_columns ||= nil
       @pluck_all_cast_klass ||= klass
       @pluck_all_uploaders ||= @pluck_all_cast_klass.uploaders.select{|key, _uploader| attributes.key?(key.to_s) }
       @pluck_all_uploaders.each do |key, _uploader|

--- a/lib/pluck_all/version.rb
+++ b/lib/pluck_all/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module PluckAll
-  VERSION = '2.1.0'
+  VERSION = '2.2.0'
 end


### PR DESCRIPTION
Fixes the `DEPRECATION WARNING: map! is deprecated and will be removed from Rails 6.2 (use map instead)` using this (and the `deep_pluck`) gem.