### PR TITLE
Fix: broken test cases caused by `mimemagic`

### DIFF
--- a/gemfiles/active_record_32.gemfile
+++ b/gemfiles/active_record_32.gemfile
@@ -5,6 +5,7 @@ source 'https://rubygems.org'
 gem 'sqlite3',      '~> 1.3.0'
 gem 'activerecord', '~> 3.2.0'
 gem 'carrierwave',  '~> 0.11.0'
+gem 'mimemagic', '< 0.4.3' # Used by carrierwave gem
 
 group :test do
   gem 'simplecov', '< 0.18'

--- a/gemfiles/active_record_42.gemfile
+++ b/gemfiles/active_record_42.gemfile
@@ -5,6 +5,7 @@ source 'https://rubygems.org'
 gem 'sqlite3',      '~> 1.3.0'
 gem 'activerecord', '~> 4.2.0'
 gem 'carrierwave',  '~> 0.11.0'
+gem 'mimemagic', '< 0.4.3' # Used by carrierwave gem
 
 group :test do
   gem 'simplecov', '< 0.18'

--- a/gemfiles/active_record_50.gemfile
+++ b/gemfiles/active_record_50.gemfile
@@ -5,6 +5,7 @@ source 'https://rubygems.org'
 gem 'sqlite3',      '~> 1.3.0'
 gem 'activerecord', '~> 5.0.0'
 gem 'carrierwave',  '~> 0.11.0'
+gem 'mimemagic', '< 0.4.3' # Used by carrierwave gem
 
 group :test do
   gem 'simplecov', '< 0.18'

--- a/gemfiles/active_record_51.gemfile
+++ b/gemfiles/active_record_51.gemfile
@@ -5,6 +5,7 @@ source 'https://rubygems.org'
 gem 'sqlite3',      '~> 1.3.0'
 gem 'activerecord', '~> 5.1.0'
 gem 'carrierwave',  '~> 0.11.0'
+gem 'mimemagic', '< 0.4.3' # Used by carrierwave gem
 
 group :test do
   gem 'simplecov', '< 0.18'

--- a/gemfiles/active_record_52.gemfile
+++ b/gemfiles/active_record_52.gemfile
@@ -5,6 +5,7 @@ source 'https://rubygems.org'
 gem 'sqlite3',      '~> 1.3.0'
 gem 'activerecord', '~> 5.2.0'
 gem 'carrierwave',  '~> 0.11.0'
+gem 'mimemagic', '< 0.4.3' # Used by carrierwave gem
 
 group :test do
   gem 'simplecov', '< 0.18'

--- a/gemfiles/active_record_60.gemfile
+++ b/gemfiles/active_record_60.gemfile
@@ -5,6 +5,7 @@ source 'https://rubygems.org'
 gem 'sqlite3',      '~> 1.4.1'
 gem 'activerecord', '~> 6.0.0'
 gem 'carrierwave',  '~> 0.11.0'
+gem 'mimemagic', '< 0.4.3' # Used by carrierwave gem
 
 group :test do
   gem 'simplecov', '< 0.18'

--- a/gemfiles/active_record_61.gemfile
+++ b/gemfiles/active_record_61.gemfile
@@ -5,6 +5,7 @@ source 'https://rubygems.org'
 gem 'sqlite3',      '~> 1.4.1'
 gem 'activerecord', '~> 6.1.0'
 gem 'carrierwave',  '~> 0.11.0'
+gem 'mimemagic', '< 0.4.3' # Used by carrierwave gem
 
 group :test do
   gem 'simplecov', '< 0.18'


### PR DESCRIPTION
Error message:
```
SyntaxError:
  /home/runner/work/pluck_all/pluck_all/vendor/bundle/ruby/2.2.0/gems/mimemagic-0.4.3/ext/mimemagic/Rakefile:31:
  syntax error, unexpected <<, expecting ')'
      f.print(<<~SOURCE
                ^
```

Caused by: https://github.com/mimemagicrb/mimemagic/pull/138

See: https://github.com/mimemagicrb/mimemagic/issues/142